### PR TITLE
Example of a Generation-Task Specification-Condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This code shows examples of how to add functionality to DriveWorks using the SDK
 Examples include:
 * Function using a Shared Project Extender and Project Extender
 * Generation Task
+* Generation Task Specification Condition
 * Specification Macro Condition
 * Specification Macro Task
 

--- a/Source/DriveWorks.Sdk.Examples.CSharp/DriveWorks.Sdk.Examples.CSharp.csproj
+++ b/Source/DriveWorks.Sdk.Examples.CSharp/DriveWorks.Sdk.Examples.CSharp.csproj
@@ -61,6 +61,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MyGenerationTaskSpecificationCondition.cs" />
     <Compile Include="MyGenerationTask.cs" />
     <Compile Include="MySpecificationMacroCondition.cs" />
     <Compile Include="MySharedProjectExtender.cs" />

--- a/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskSpecificationCondition.cs
+++ b/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskSpecificationCondition.cs
@@ -1,29 +1,32 @@
 ﻿using DriveWorks.Components.Tasks;
 using DriveWorks.Specification;
 
-/// <summary>
-/// A Generation Task Specification Condition which determines whether the value entered is even.
-/// </summary>
-/// <remarks><see cref="ComponentTaskReleaseCondition"/> are evaluated at the time of releasing component-sets.</remarks>
-[ComponentTaskCondition("Is Even",
-                        "Passes if the specified value is even.",
-                        "embedded://DriveWorks.Sdk.Examples.CSharp.Puzzle-16x16.png",
-                        "SDK-Starter-Examples Plugin")]
-public class MyGenerationTaskSpecificationCondition : ComponentTaskReleaseCondition
+namespace DriveWorks.Sdk.Examples.CSharp
 {
-    private readonly FlowProperty<double> mValue;
-
-    public MyGenerationTaskSpecificationCondition()
+    /// <summary>
+    /// A Generation Task Specification Condition which determines whether the value entered is even.
+    /// </summary>
+    /// <remarks><see cref="ComponentTaskReleaseCondition"/> are evaluated at the time of releasing component-sets.</remarks>
+    [ComponentTaskCondition("Is Even",
+                            "Passes if the specified value is even.",
+                            "embedded://DriveWorks.Sdk.Examples.CSharp.Puzzle-16x16.png",
+                            "SDK-Starter-Examples Plugin")]
+    public class MyGenerationTaskSpecificationCondition : ComponentTaskReleaseCondition
     {
-        mValue = this.Properties.RegisterDoubleProperty("Value",
-                                                        "The value to check for must be an even number for the condition to pass.");
-    }
+        private readonly FlowProperty<double> mValue;
 
-    protected override bool Evaluate(SpecificationContext specificationContext)
-    {
-        // If a number is evenly divisible by 2 with no remainder, then it is even.
-        var isEven = (mValue.Value % 2) == 0;
+        public MyGenerationTaskSpecificationCondition()
+        {
+            mValue = this.Properties.RegisterDoubleProperty("Value",
+                                                            "The value to check for must be an even number for the condition to pass.");
+        }
 
-        return isEven;
+        protected override bool Evaluate(SpecificationContext specificationContext)
+        {
+            // If a number is evenly divisible by 2 with no remainder, then it is even.
+            var isEven = (mValue.Value % 2) == 0;
+
+            return isEven;
+        }
     }
 }

--- a/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskSpecificationCondition.cs
+++ b/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskSpecificationCondition.cs
@@ -1,0 +1,29 @@
+﻿using DriveWorks.Components.Tasks;
+using DriveWorks.Specification;
+
+/// <summary>
+/// A Generation Task Specification Condition which determines whether the value entered is even.
+/// </summary>
+/// <remarks><see cref="ComponentTaskReleaseCondition"/> are evaluated at the time of releasing component-sets.</remarks>
+[ComponentTaskCondition("Is Even",
+                        "Passes if the specified value is even.",
+                        "embedded://DriveWorks.Sdk.Examples.CSharp.Puzzle-16x16.png",
+                        "SDK-Starter-Examples Plugin")]
+public class MyGenerationTaskSpecificationCondition : ComponentTaskReleaseCondition
+{
+    private readonly FlowProperty<double> mValue;
+
+    public MyGenerationTaskSpecificationCondition()
+    {
+        mValue = this.Properties.RegisterDoubleProperty("Value",
+                                                        "The value to check for must be an even number for the condition to pass.");
+    }
+
+    protected override bool Evaluate(SpecificationContext specificationContext)
+    {
+        // If a number is evenly divisible by 2 with no remainder, then it is even.
+        var isEven = (mValue.Value % 2) == 0;
+
+        return isEven;
+    }
+}

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
@@ -126,7 +126,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Puzzle-16x16.png" />
     <EmbeddedResource Include="Puzzle-16x16.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
@@ -84,6 +84,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MyGenerationTaskSpecificationCondition.vb" />
     <Compile Include="MyGenerationTask.vb" />
     <Compile Include="MySpecificationMacroCondition.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
@@ -126,6 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Puzzle-16x16.png" />
+    <EmbeddedResource Include="Puzzle-16x16.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
 </Project>

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/MyGenerationTaskSpecificationCondition.vb
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/MyGenerationTaskSpecificationCondition.vb
@@ -1,0 +1,26 @@
+﻿Imports DriveWorks.Components.Tasks
+Imports DriveWorks.Specification
+
+''' <summary>
+''' A Generation Task Specification Condition which determines whether the value entered is even.
+''' </summary>
+''' <remarks><see cref="ComponentTaskReleaseCondition"/> are evaluated at the time of releasing component-sets.</remarks>
+<ComponentTaskCondition("Is Even",
+                        "Passes if the specified value is even.",
+                        "embedded://DriveWorks.Sdk.Examples.VbDotNet.Puzzle-16x16.png",
+                        "SDK-Starter-Examples Plugin")>
+Public Class MyGenerationTaskSpecificationCondition
+    Inherits ComponentTaskReleaseCondition
+
+    Private ReadOnly mValue As FlowProperty(Of Double) = Me.Properties.RegisterDoubleProperty("Value",
+                                                                                              "The value to check for must be an even number for the condition to pass.")
+
+    Protected Overrides Function Evaluate(specificationContext As SpecificationContext) As Boolean
+
+        ' If a number is evenly divisible by 2 with no remainder, then it is even.
+        Dim isEven = (mValue.Value Mod 2) = 0
+
+        Return isEven
+
+    End Function
+End Class


### PR DESCRIPTION
### Intent
This is to show how to create a custom **Generation-Task Specification-Condition**.
This is so you can control whether one or more **Generation Tasks** should be included in the **generation sequence** of a **released component-set**. 

These conditions are evaluated at the time of **releasing the component**, not when generating them. (see [Generation-Task Generation-Condition](https://github.com/DriveWorks/SDK-Starter-Examples/issues/12) for how to create a condition that is evaluated when models are generated instead.)

### Example
This PR introduces 2 new classes called `MyGenerationTaskSpecificationCondition`, one in C#, one in VB.
Both show how to declare a condition that checks if the provided number is even or odd. 
The conditions will pass if the number is even and fail otherwise.

### Implementation Details
To add a **Generation-Task Specification-Condition** you need to create a new class that inherits `ComponentTaskReleaseCondition` as well as decorating it with a `ComponentTaskCondition` attribute.
Then you need to override its `protected override bool Evaluate(SpecificationContext specificationContext)` method.
Returning `true` will pass the condition, `false` will mark it as failed.
#### Note 
This method is also provided with a `SpecificationContext` so the condition can access information about the current Specification when it evaluates, although it isn't used in this PR.