### PR TITLE
Example of a Generation-Task Generation-Condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This code shows examples of how to add functionality to DriveWorks using the SDK
 Examples include:
 * Function using a Shared Project Extender and Project Extender
 * Generation Task
+* Generation Task Generation Condition
 * Specification Macro Condition
 * Specification Macro Task
 

--- a/Source/DriveWorks.Sdk.Examples.CSharp/DriveWorks.Sdk.Examples.CSharp.csproj
+++ b/Source/DriveWorks.Sdk.Examples.CSharp/DriveWorks.Sdk.Examples.CSharp.csproj
@@ -61,6 +61,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MyGenerationTaskGenerationCondition.cs" />
     <Compile Include="MyGenerationTask.cs" />
     <Compile Include="MySpecificationMacroCondition.cs" />
     <Compile Include="MySharedProjectExtender.cs" />

--- a/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskGenerationCondition.cs
+++ b/Source/DriveWorks.Sdk.Examples.CSharp/MyGenerationTaskGenerationCondition.cs
@@ -1,0 +1,38 @@
+﻿using DriveWorks.Components;
+using DriveWorks.SolidWorks;
+using DriveWorks.SolidWorks.Generation;
+using DriveWorks.SolidWorks.Generation.Proxies;
+
+namespace DriveWorks.Sdk.Examples.CSharp
+{
+    /// <summary>
+    /// A Generation Task Generation Condition which determines whether the model has multiple configurations.
+    /// </summary>
+    /// <remarks><see cref="GenerationTaskCondition"/> are evaluated at the time of generating component-sets.</remarks>
+    [GenerationTaskCondition("Has Multiple Configurations",
+                             "Checks whether the model has multiple configurations.",
+                             "embedded://DriveWorks.Sdk.Examples.CSharp.Puzzle-16x16.png",
+                             "SDK-Starter-Examples Plugin",
+                             GenerationTaskScope.Parts | GenerationTaskScope.Assemblies)]
+    public class MyGenerationTaskGenerationCondition : GenerationTaskCondition
+    {
+        protected override bool Evaluate(SldWorksModelProxy model, ReleasedComponent component, GenerationSettings generationSettings)
+        {
+            // Using the provided SldWorksModelProxy object to query information from the current model.
+            var nbrOfConfigurations = model.Model.GetConfigurationCount();
+            var hasMultipleConfigurations = nbrOfConfigurations > 1;
+
+            // EvaluationResultDetails will be used by DriveWorks for reporting in the Model Generation Reports or Model Insight.
+            if (hasMultipleConfigurations)
+            {
+                this.EvaluationResultDetails = $"The component has multiple configurations. ({nbrOfConfigurations} found).";
+            }
+            else
+            {
+                this.EvaluationResultDetails = "The component has 1 configuration only.";
+            }
+
+            return hasMultipleConfigurations;
+        }
+    }
+}

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
@@ -126,7 +126,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Puzzle-16x16.png" />
     <EmbeddedResource Include="Puzzle-16x16.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/DriveWorks.Sdk.Examples.VbDotNet.vbproj
@@ -84,6 +84,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MyGenerationTaskGenerationCondition.vb" />
     <Compile Include="MyGenerationTask.vb" />
     <Compile Include="MySpecificationMacroCondition.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
@@ -126,6 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Puzzle-16x16.png" />
+    <EmbeddedResource Include="Puzzle-16x16.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
 </Project>

--- a/Source/DriveWorks.Sdk.Examples.VbDotNet/MyGenerationTaskGenerationCondition.vb
+++ b/Source/DriveWorks.Sdk.Examples.VbDotNet/MyGenerationTaskGenerationCondition.vb
@@ -1,0 +1,36 @@
+﻿Imports DriveWorks.Components
+Imports DriveWorks.SolidWorks
+Imports DriveWorks.SolidWorks.Generation
+Imports DriveWorks.SolidWorks.Generation.Proxies
+
+''' <summary>
+''' A Generation Task Generation Condition which determines whether the model has multiple configurations.
+''' </summary>
+''' <remarks><see cref="GenerationTaskCondition"/> are evaluated at the time of generating component-sets.</remarks>
+<GenerationTaskCondition("Has Multiple Configurations",
+                         "Checks whether the model has multiple configurations.",
+                         "embedded://DriveWorks.Sdk.Examples.VbDotNet.Puzzle-16x16.png",
+                         "SDK-Starter-Examples Plugin",
+                         GenerationTaskScope.Parts Or GenerationTaskScope.Assemblies)>
+Public Class MyGenerationTaskGenerationCondition
+    Inherits GenerationTaskCondition
+
+    Protected Overrides Function Evaluate(model As SldWorksModelProxy, component As ReleasedComponent, generationSettings As GenerationSettings) As Boolean
+
+        ' Using the provided SldWorksModelProxy object to query information from the current model.
+        Dim nbrOfConfigurations = model.Model.GetConfigurationCount()
+        Dim hasMultipleConfigurations = nbrOfConfigurations > 1
+
+        ' EvaluationResultDetails will be used by DriveWorks for reporting in the Model Generation Reports or Model Insight.
+        If hasMultipleConfigurations Then
+
+            Me.EvaluationResultDetails = $"The component has multiple configurations. ({nbrOfConfigurations} found)."
+        Else
+
+            Me.EvaluationResultDetails = "The component has 1 configuration only."
+        End If
+
+        Return hasMultipleConfigurations
+
+    End Function
+End Class


### PR DESCRIPTION
### Intent
This is to show how to create a custom **Generation-Task Generation-Condition**.
This is so you can control whether one or more **Generation Tasks** should be executed when a **released component-set** is generated. 

These conditions are evaluated at the time of **generating components**, not when releasing them. (see [Generation-Task Specification-Condition](https://github.com/DriveWorks/SDK-Starter-Examples/issues/2) for how to create a condition that is evaluated when models are released instead.)

### Example
This PR introduces 2 new classes called `MyGenerationTaskGenerationCondition`, one in C#, one in VB.
Both show how to declare a condition that checks if the current model has more than 1 SOLIDWORKS Configuration. 
The conditions will pass if multiple configurations can be found and fail otherwise.

### Implementation Details
To add a **Generation-Task Generation-Condition** you need to create a new class that inherits `GenerationTaskCondition` as well as decorating it with a `GenerationTaskCondition` attribute.
Then you need to override its `protected override bool Evaluate(SldWorksModelProxy model, ReleasedComponent component, GenerationSettings generationSettings)` method.
Returning `true` will pass the condition, `false` will mark it as failed.
Setting the `EvaluationResultDetails` string can be used so that DriveWorks add report entries in Model Generation Reports and in Model-Insight.
#### Note 
This method is also provided with a `ReleasedComponent` parameter and a `GenerationSettings` parameter so the condition can access information about the released component and the settings values of the current DriveWorks Module when it evaluates, although it isn't used in this PR.